### PR TITLE
reset content each time we call video.watermark

### DIFF
--- a/src/videojs.watermark.js
+++ b/src/videojs.watermark.js
@@ -9,7 +9,8 @@ console.log('watermark: Start');
         xrepeat: 0,
         opacity: 100,
         clickable: false,
-        url: ""
+        url: "",
+        className: 'vjs-watermark'
     },
     extend = function() {
       var args, target, i, object, property;
@@ -48,7 +49,7 @@ console.log('watermark: Start');
     // create the watermark element
     if (!div) {
         div = document.createElement('div');
-        div.className = 'vjs-watermark';
+        div.className = options.className;
     }
     else {
         //! if div already exists, empty it

--- a/src/videojs.watermark.js
+++ b/src/videojs.watermark.js
@@ -30,21 +30,30 @@ console.log('watermark: Start');
       return target;
     };
 
+    //! global varible containing reference to the DOM element
+    var div;
+
   /**
    * register the thubmnails plugin
    */
   videojs.plugin('watermark', function(options) {
     console.log('watermark: Register init');
 
-    var settings, video, div, img, link;
+    var settings, video, img, link;
     settings = extend(defaults, options);
 
     /* Grab the necessary DOM elements */
     video = this.el();
 
     // create the watermark element
-    div = document.createElement('div');
-    div.className = 'vjs-watermark';
+    if (!div) {
+        div = document.createElement('div');
+        div.className = 'vjs-watermark';
+    }
+    else {
+        //! if div already exists, empty it
+        div.innerHTML = '';
+    }
 
     // if text is set, display text
     if (options.text)


### PR DESCRIPTION
Hi,

I'm currently using your plugin with the videoJS-playLists plugin and I sometimes need to update the watermark.

However, each time we call `video.watermark({ ... })`, it does not clean the previous content but add the new content over the previous one.

With this commit we can do:

```js
// at first
video.watermark({
  file: 'http://www.videojs.com/img/logo.png',
  xpos: 50,
  ypos: 50,
  xrepeat: 0,
  opacity: 0.5
  });

// then later
video.watermark({
  file: 'http://www.videojs.com/img/an_other_logo.png',
  xpos: 50,
  ypos: 50,
  xrepeat: 0,
  opacity: 0.5
  });
```

This will remove the first content and replace it with the new one.